### PR TITLE
Fix minor typo

### DIFF
--- a/src/qt/qt_mainwindow.ui
+++ b/src/qt/qt_mainwindow.ui
@@ -942,7 +942,7 @@
     <bool>true</bool>
    </property>
    <property name="text">
-    <string>&amp;Square pixels (keep ratio)</string>
+    <string>&amp;Square pixels (Keep ratio)</string>
    </property>
   </action>
   <action name="action_Integer_scale_gl">


### PR DESCRIPTION
Summary
=======
Fixes a minor typo that causes a string to not be translated added by commit 18cdab5

Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
